### PR TITLE
Linux 构建配置

### DIFF
--- a/src/painttyDesktop/painttyDesktop.pro
+++ b/src/painttyDesktop/painttyDesktop.pro
@@ -23,6 +23,10 @@ win32 {
     HEADERS +=
 }
 
+linux {
+    QMAKE_LFLAGS += -no-pie
+}
+
 mac {
     macx-clang: warning("if you encounter \"fatal error: \'initializer_list\' file not found\", try using makespecs \"macx-clang-libc++\"")
     ICON = iconset/icon.icns
@@ -32,7 +36,14 @@ include(../../commonconfigure.pri)
 
 CONFIG += c++11
 
-TARGET = MrPaint
+linux{
+    TARGET = mrpaint
+}
+
+!linux{
+    TARGET = MrPaint
+}
+
 TEMPLATE = app
 
 SOURCES += main.cpp\


### PR DESCRIPTION
未修改程序代码条件下，在 Ubuntu 20.04 amd64 Qt 5.12.8 下可以顺利编译并正常运行
- 让目标二进制文件可以被gnome桌面的图形文件管理器识别直接运行

- 设置linux构建目标文件名为全小写以符合规范

注：linux下配置文件存储在用户home文件夹下。