### PR TITLE
更友好的色轮组件

### DIFF
--- a/src/painttyDesktop/widgets/colorwheel.cpp
+++ b/src/painttyDesktop/widgets/colorwheel.cpp
@@ -82,7 +82,7 @@ QColor ColorWheel::posColor(const QPoint &point)
         // NOTICE: if width is 98px, then we only have 0~97px as range. That's why we decrase w by 1.
         return QColor::fromHsv(current.hue(),
                                qBound(0, p.x() * 255 / (w-1), 255),
-                               qBound(0, 255 - p.y() * 255 / (w-1), 255));
+                               qBound(0, p.y() * 255 / (w-1), 255));
     }
     return QColor();
 }
@@ -228,7 +228,7 @@ void ColorWheel::drawSquareImage(const int &hue)
     QRgb vv;
     for(int i=0;i<255;++i){
         for(int j=0;j<255;++j){
-            color = QColor::fromHsv(hue,i,j);
+            color = QColor::fromHsv(hue,i,254-j);
             vv = qRgb(color.red(), color.green(), color.blue());
             square.setPixel(i, j, vv);
         }
@@ -276,7 +276,7 @@ void ColorWheel::drawPicker(const QColor &color)
     painter.translate(m-5, m-5);
     qreal SquareWidth = 2*ir/qSqrt(2);
     qreal S = color.saturationF()*SquareWidth;
-    qreal V = color.valueF()*SquareWidth;
+    qreal V = (1.0-color.valueF())*SquareWidth;
 
     if(color.saturation() > 30 ||color.value() < 50){
         pen.setColor(Qt::white);


### PR DESCRIPTION
一般的绘画软件，饱和度/明度选框都是上亮下暗，不知道为什么茶绘君原来会写成反过来的。像我就觉得很不舒服。
比如sai2：
![image](https://user-images.githubusercontent.com/19867269/81327157-6c6d0180-90cd-11ea-83c9-9f7b968b6f9e.png)
修改前：
![@W1E$E(WXHUUE5GO0(6}0KF](https://user-images.githubusercontent.com/19867269/81327049-4cd5d900-90cd-11ea-9f37-6a91688641f8.png)
修改后：
![VH)(N%IE{9VUZ5)`QZ44~J8](https://user-images.githubusercontent.com/19867269/81327260-94f4fb80-90cd-11ea-977f-febd8aeeec45.png)
还有就是spinbox默认是rgb模式也很奇怪，不搭，但我还没研究出怎么改成功。